### PR TITLE
execute reports in reports.py

### DIFF
--- a/app/reports.py
+++ b/app/reports.py
@@ -1,25 +1,144 @@
-from app.forms import MissingFieldReportForm, MissingSubfieldReportForm
+from app.forms import FlaskForm, MissingFieldReportForm, MissingSubfieldReportForm
+from dlx.marc.record import Matcher
+from app.config import Config
+from dlx import DB, Bib, Auth
+from dlx.marc.record import Matcher
+from bson.regex import Regex
+
+DB.connect(Config.connect_string)
 
 class Report(object):
-    def __init__(self, name, title, description, form_class):
-        self.name = name
-        self.title = title
-        self.description = description
-        self.form_class = form_class
+    def __init__(self):
+        # these attributes must be implmeted by the subclass
+        self.name = None
+        self.title = None
+        self.description = None
+        self.form_class = None
+        self.expected_params = None
+        self.stored_criteria = None
+        self.output_fields = None
+           
+    def validate_args(self,args):
+        for param in self.expected_params:
+            if param not in args.keys():
+                raise Exception('Param "{}" not found'.format(param))
+        
+    def execute(self,args):
+        self.validate_args(args)
+        
+        # todo
+        # generic execution
+        
+### standard reports
+        
+class MissingFieldReport(Report):
+    def __init__(self):
+        #super().__init__(self)
+        
+        self.name = 'missing_field'
+        self.title = 'Missing Field Report'
+        self.description = 'This report returns bib numbers and document symbols based on a particular body and session for the specified field.'
+        self.form_class = MissingFieldReportForm
+        
+        self.expected_params = ('authority','field')
+        self.stored_criteria = [],
+        self.output_fields = [
+            ('930','a'),
+            ('001',None),
+            ('191','a')
+        ]
+        
+    # overrides parent method    
+    def execute(self,args):
+        self.validate_args(args)
+        
+        auth = _get_auth(args['authority'])
+        body,session = _get_body_session(auth)
+        
+        tag = args['field']
+        
+        bibs = Bib.match(
+            # these actaully are not necessary because ITS and VOT records don't have 191,
+            # so they're already exluded
+            #Matcher('930',('a','VOT'),modifier='not'),
+            #Matcher('930',('a','ITS'),modifier='not'),
+            
+            Matcher('191',('b',body),('c',session)),
+            Matcher(tag,modifier='not_exists')
+        )
+        
+        results = []
+        
+        for bib in bibs:
+            results.append([bib.get_value(*out) for out in self.output_fields])
+        
+        # list of lists
+        return results
+        
+class MissingSubfieldReport(Report):
+    def __init__(self):
+        self.name = 'missing_subfield'
+        self.title = 'Missing Subfield Report'
+        self.description = 'This report returns bib numbers and document symbols based on a particular body and session for the specified field and subfield.'
+        self.form_class = MissingSubfieldReportForm
+        
+        self.expected_params = ('authority','field','subfield')
+        self.stored_criteria = [],
+        self.output_fields = [
+            ('930','a'),
+            ('001',None),
+            ('191','a')
+        ]
+        
+    def execute(self,args):
+        self.validate_args(args)
+        
+        auth = _get_auth(args['authority'])
+        body,session = _get_body_session(auth)
+    
+        tag = args['field']
+        subfield = args['subfield']
+        
+        bibs = Bib.match(
+            Matcher('191',('b',body),('c',session)),
+            Matcher(tag,(subfield,Regex('^.')),modifier='not')
+        )
+        
+        results = []
+        
+        for bib in bibs:
+            results.append([bib.get_value(*out) for out in self.output_fields])
+        
+        # list of lists
+        return results
+        
+        
+### utility functions
+
+def _get_auth(string):
+    try:
+        auth_id = int(string)
+        auth = Auth.match_id(auth_id)
+    except ValueError:
+        body,session = string.split('/')
+        auth = next(Auth.match(Matcher('190',('b',body+'/'),('c',session))),None)
+        
+    return auth
+    
+def _get_body_session(auth):
+    if auth is None:
+        return([['Auth not found']])
+    else:
+        body = auth.get_value('190','b')
+        session = auth.get_value('190','c')
+    
+    return (body,session)
+            
+### use for now
 
 class ReportList(object):
     reports = [
-        Report(
-            name='missing_field',
-            title='Missing Field Report',
-            description='This report returns bib numbers and document symbols based on a particular body and session for the specified field. For the authority field you can insert the number or use the format body/session (eg:A/72) is alsp available for the search.',
-            form_class= MissingFieldReportForm
-        ),
-
-        #Report(
-        #    name='missing_subfield',
-        #    title='Missing Subfield Report',
-        #    description= 'This report returns bib numbers and document symbols based on a particular body and session for the specified field and subfield.',
-        #    form_class= MissingSubfieldReportForm
-        #)
+       MissingFieldReport(),
+       MissingSubfieldReport()
     ]
+    


### PR DESCRIPTION
Both reports work now. I removed _run_report() and moved the report execution to reports.py. Now the report objects have a method called execute(), which is called from app.get_report_by_id()

#22