### PR TITLE
reorg config

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -8,7 +8,7 @@ from app.forms import LoginForm
 from app.reports import ReportList, AuthNotFound, InvalidInput
 from datetime import datetime
 from werkzeug.utils import secure_filename
-from app.config import DevelopmentConfig as Config
+from app.config import Config
 from dlx import DB, Bib, Auth
 import time
 

--- a/app/config.py
+++ b/app/config.py
@@ -31,26 +31,33 @@ Travis CI, you will need to make sure your CI environment has the appropriate va
 and stored.
 '''
 
-class Config(object):
-    # how many results per page
-    RPP = 10
-
+class ProductionConfig(object):
     client = boto3.client('ssm')
-    
-    if os.environ['FLASK_TESTING'] == '1':
-        connect_string = 'mongomock://localhost'
-    else:
-        connect_string = client.get_parameter(Name='connect-string')['Parameter']['Value']
-        dbname = client.get_parameter(Name='dbname')['Parameter']['Value']
-    
+    connect_string = client.get_parameter(Name='connect-string')['Parameter']['Value']
+    dbname = client.get_parameter(Name='dbname')['Parameter']['Value']
     collection_prefix = ''
+    RPP = 10
     
-class ProductionConfig(Config):
-    DEBUG = False
-    
-class DevelopmentConfig(Config):
+class DevelopmentConfig(ProductionConfig):
     # Provide overrides for production settings here.
     collection_prefix = 'dev_'
     DEBUG = True
+
+class TestConfig(ProductionConfig):
+    DEBUG = True
+    collection_prefix = ''
+    connect_string = 'mongomock://localhost'
     
+def get_config():
+    flask_env = os.environ.setdefault('FLASK_ENV','development')
+
+    print(flask_env)
     
+    if flask_env == 'production':
+        return ProductionConfig
+    elif flask_env == 'development':
+        return DevelopmentConfig
+    else:
+        return TestConfig
+
+Config = get_config()

--- a/app/models.py
+++ b/app/models.py
@@ -2,7 +2,7 @@ from mongoengine import *
 from flask_login import UserMixin
 from werkzeug.security import check_password_hash, generate_password_hash
 import time
-from app.config import DevelopmentConfig as Config
+from app.config import Config
 
 class Itpp_user(UserMixin, Document):
     """


### PR DESCRIPTION
This builds on the previous commit to interrogate the environment for a FLASK_ENV variable and set it to 'development' if it isn't found. Then the config conducts a test to see what that variable is and returns the appropriate configuration object. This provides a clear separation between configuration contexts and in theory prevents the application from defaulting to the production settings.