### PR TITLE
Config

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -49,15 +49,16 @@ class TestConfig(ProductionConfig):
     connect_string = 'mongomock://localhost'
     
 def get_config():
-    flask_env = os.environ.setdefault('FLASK_ENV','development')
+    if 'FLASK_TEST' in os.environ:
+        return TestConfig
 
-    print(flask_env)
+    flask_env = os.environ['FLASK_ENV']
     
     if flask_env == 'production':
         return ProductionConfig
     elif flask_env == 'development':
         return DevelopmentConfig
     else:
-        return TestConfig
+        raise Exception('Environment variable "FLASK_ENV" set to invalid value "{}"'.format(flask_env))
 
 Config = get_config()

--- a/app/config.py
+++ b/app/config.py
@@ -52,7 +52,7 @@ def get_config():
     if 'FLASK_TEST' in os.environ:
         return TestConfig
 
-    flask_env = os.environ['FLASK_ENV']
+    flask_env = os.environ.setdefault('FLASK_ENV', 'development')
     
     if flask_env == 'production':
         return ProductionConfig


### PR DESCRIPTION
This allows the test config to be used without changing FLASK_ENV, which should be set to "development" for debugging purposes when testing.