### PR TITLE
Fix sorting for speeches

### DIFF
--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -624,7 +624,7 @@ def itpitss(bodysession):
                                 }
                             }, 
                             'find': '—', 
-                            'replacement': ' $'}
+                            'replacement': ' —'} # $
                         },
                         '+',
                         {'$replaceAll': {
@@ -636,7 +636,7 @@ def itpitss(bodysession):
                                 }
                             }, 
                             'find': '—', 
-                            'replacement': ' $'}
+                            'replacement': ' —'} # $
                         },
                     ]
                 },

--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -427,7 +427,7 @@ def itpitsp(bodysession):
                             }
                         }, 
                         'find': '—', 
-                        'replacement': ' $'
+                        'replacement': ' —'
                     }
                 }, 
                 'sortkey3': '$docsymbol'

--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -597,7 +597,25 @@ def itpitss(bodysession):
                         'replacement': ' $'
                     }
                 },
-                'sortkey2': '$itsentry', 
+                'sortkey2': {
+                    '$replaceAll': {
+                        'input': {
+                            '$replaceAll': {
+                                'input': {
+                                    '$replaceAll': {
+                                        'input': {'$concat': [{'$toUpper': '$itsentry'}, '+']}, 
+                                        'find': ' ', 
+                                        'replacement': '!'
+                                    }
+                                }, 
+                                'find': ',', 
+                                'replacement': ' '
+                            }
+                        }, 
+                        'find': '-', 
+                        'replacement': '^'
+                        }
+                },
                 'sortkey3': '$docsymbol'
             }
         }
@@ -624,6 +642,8 @@ def itpitss(bodysession):
         pipeline.append(sort_stage)
     
         pipeline.append(merge_stage)
+
+        print(pipeline)
 
         inputCollection.aggregate(pipeline, collation=collation)
 
@@ -3775,7 +3795,7 @@ def group_speeches(section, bodysession):
     pipeline.append(project_stage)
     pipeline.append(merge_stage)
 
-    #print(pipeline)
+    print(pipeline)
 
     outputCollection.aggregate(pipeline)
 

--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -169,21 +169,54 @@ def itpitsc(bodysession):
                 'itsentry': 1, 
                 'docsymbol': 1, 
                 'sortkey1': {
+                    '$concat': [
+                        {
+                            '$replaceAll': {
+                                'input': {
+                                    '$replaceAll': {
+                                        'input': {'$toUpper': '$itshead'}, #corporate
+                                        'find': '. ', 
+                                        'replacement': ' .'
+                                    }
+                                }, 
+                                'find': '—', 
+                                'replacement': ' $'
+                            }
+                        },
+                        '+',
+                        {
+                            '$replaceAll': {
+                                'input': {
+                                    '$replaceAll': {
+                                        'input': {'$toUpper':'$itssubhead'}, #subject
+                                        'find': '. ', 
+                                        'replacement': ' .'
+                                    }
+                                }, 
+                                'find': '—', 
+                                'replacement': ' $'
+                            }
+                        },
+                ]},
+                'sortkey2': {
                     '$replaceAll': {
                         'input': {
                             '$replaceAll': {
                                 'input': {
-                                    '$concat': [
-                                        {'$toUpper': '$itshead'}, '+', {'$toUpper':'$itssubhead'}]}, 
-                                'find': '. ', 
-                                'replacement': ' .'
+                                    '$replaceAll': {
+                                        'input': {'$toUpper': '$itsentry'}, #speaker
+                                        'find': ' ', 
+                                        'replacement': '!'
+                                    }
+                                }, 
+                                'find': ',', 
+                                'replacement': ' '
                             }
                         }, 
-                        'find': '—', 
-                        'replacement': ' $'
+                    'find': '-', 
+                    'replacement': '^'
                     }
                 },
-                'sortkey2': '$itsentry', 
                 'sortkey3': '$docsymbol'
             }
         }
@@ -388,9 +421,7 @@ def itpitsp(bodysession):
                     '$replaceAll': {
                         'input': {
                             '$replaceAll': {
-                                'input': {
-                                    '$concat': [
-                                        {'$toUpper': '$itssubhead'}, '+']}, 
+                                'input': {'$toUpper': '$itssubhead'}, #subject 
                                 'find': '. ', 
                                 'replacement': ' .'
                             }
@@ -583,19 +614,31 @@ def itpitss(bodysession):
                 'itsentry': 1, 
                 'docsymbol': 1, 
                 'sortkey1': {
-                    '$replaceAll': {
-                        'input': {
-                            '$replaceAll': {
-                                'input': {
-                                    '$concat': [
-                                        {'$toUpper': '$agendasubject'}, '+', {'$toUpper':'$itssubhead'}]}, 
-                                'find': '. ', 
-                                'replacement': ' .'
-                            }
-                        }, 
-                        'find': '—', 
-                        'replacement': ' $'
-                    }
+                    '$concat': [
+                        {'$replaceAll': {
+                            'input': {
+                                '$replaceAll': {
+                                    'input': {'$toUpper': '$agendasubject'}, #subject
+                                    'find': '. ', 
+                                    'replacement': ' .'
+                                }
+                            }, 
+                            'find': '—', 
+                            'replacement': ' $'}
+                        },
+                        '+',
+                        {'$replaceAll': {
+                            'input': {
+                                '$replaceAll': {
+                                    'input': {'$toUpper':'$itssubhead'}, #corporate
+                                    'find': '. ', 
+                                    'replacement': ' .'
+                                }
+                            }, 
+                            'find': '—', 
+                            'replacement': ' $'}
+                        },
+                    ]
                 },
                 'sortkey2': {
                     '$replaceAll': {
@@ -603,7 +646,7 @@ def itpitss(bodysession):
                             '$replaceAll': {
                                 'input': {
                                     '$replaceAll': {
-                                        'input': {'$concat': [{'$toUpper': '$itsentry'}, '+']}, 
+                                        'input': {'$toUpper': '$itsentry'},  #speaker
                                         'find': ' ', 
                                         'replacement': '!'
                                     }
@@ -643,7 +686,7 @@ def itpitss(bodysession):
     
         pipeline.append(merge_stage)
 
-        print(pipeline)
+        #print(pipeline)
 
         inputCollection.aggregate(pipeline, collation=collation)
 
@@ -3795,9 +3838,15 @@ def group_speeches(section, bodysession):
     pipeline.append(project_stage)
     pipeline.append(merge_stage)
 
-    print(pipeline)
+    #print(pipeline)
 
-    outputCollection.aggregate(pipeline)
+    #outputCollection.aggregate(pipeline)
+
+    outputCollection.aggregate(pipeline, 
+        collation={
+            'locale': 'en', 
+            'strength': 1, #ignore diacritics
+        })
 
 def group_itpitsp(section, bodysession):
 

--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -222,28 +222,6 @@ def itpitsc(bodysession):
                     'replacement': '^'
                     }
                 },
-<<<<<<< HEAD
-=======
-                'sortkey2': {
-                '$replaceAll': {
-                    'input': {
-                        '$replaceAll': {
-                            'input': {
-                                '$replaceAll': {
-                                    'input': {'$concat': [{'$toUpper': '$itsentry'}, '+']}, 
-                                    'find': ' ', 
-                                    'replacement': '!'
-                                }
-                            }, 
-                            'find': ',', 
-                            'replacement': ' '
-                        }
-                    }, 
-                    'find': '-', 
-                    'replacement': '^'
-                    }
-                },
->>>>>>> 17d2aafee4e31d8cb0f546b23089f12c78d9adff
                 'sortkey3': '$docsymbol'
             }
         }
@@ -696,28 +674,6 @@ def itpitss(bodysession):
                         'replacement': '^'
                         }
                 },
-<<<<<<< HEAD
-=======
-                'sortkey2': {
-                '$replaceAll': {
-                    'input': {
-                        '$replaceAll': {
-                            'input': {
-                                '$replaceAll': {
-                                    'input': {'$concat': [{'$toUpper': '$itsentry'}, '+']}, 
-                                    'find': ' ', 
-                                    'replacement': '!'
-                                }
-                            }, 
-                            'find': ',', 
-                            'replacement': ' '
-                        }
-                    }, 
-                    'find': '-', 
-                    'replacement': '^'
-                    }
-                }, 
->>>>>>> 17d2aafee4e31d8cb0f546b23089f12c78d9adff
                 'sortkey3': '$docsymbol'
             }
         }
@@ -3919,11 +3875,8 @@ def group_speeches(section, bodysession):
 
     #print(pipeline)
 
-<<<<<<< HEAD
     #outputCollection.aggregate(pipeline)
 
-=======
->>>>>>> 17d2aafee4e31d8cb0f546b23089f12c78d9adff
     outputCollection.aggregate(pipeline, 
         collation={
             'locale': 'en', 

--- a/app/aggregations.py
+++ b/app/aggregations.py
@@ -180,7 +180,7 @@ def itpitsc(bodysession):
                                     }
                                 }, 
                                 'find': '—', 
-                                'replacement': ' $'
+                                'replacement': ' —'
                             }
                         },
                         '+',
@@ -194,7 +194,7 @@ def itpitsc(bodysession):
                                     }
                                 }, 
                                 'find': '—', 
-                                'replacement': ' $'
+                                'replacement': ' —'
                             }
                         },
                 ]},


### PR DESCRIPTION
Reverted back to commit f96d9a0d102ce1d4149fd3ccbcddaa033d81e50c in order to correct changes introduced into the sorting for the speeches sections. The bug was an unintended consequence of collation and the reserved symbol ' $' which was in the original sortkey from the old process.